### PR TITLE
docs: update README to use proper link and username in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ The final solution should only show a button if the GitHub user profile if the G
 
 API example:
 
-When viewing [bdougie](https://github.com/bdougie) you will check his handle using the users service in api.opensauced.pizza to confirm he is an OpenSauced user. When checking [bdougie](https://github.com/defunkt) you will confirm he is not an OpenSauced user.
+When viewing [bdougie](https://github.com/bdougie) you will check his handle using the users service in api.opensauced.pizza to confirm he is an OpenSauced user. When checking [defunkt](https://github.com/defunkt) you will confirm he is not an OpenSauced user.
 
 ```
-https://api.opensauced.pizza/v1/users/defunkt // returns 200
+https://api.opensauced.pizza/v1/users/bdougie // returns 200
 https://api.opensauced.pizza/v1/users/defunkt // return 404
 ```
 


### PR DESCRIPTION
This PR addresses the following issues in the README file:
- In the user example, different username has been used rather than the username it is redirecting to.
- In the API example, same username is used twice to show 200 and 404 status codes.