### PR TITLE
chore: Update outdated info about OpenSauced API v1 `/users` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,19 @@ API example:
 
 When viewing [bdougie](https://github.com/bdougie) you will check his handle using the users service in api.opensauced.pizza to confirm he is an OpenSauced user. When checking [defunkt](https://github.com/defunkt) you will confirm he is not an OpenSauced user.
 
+>**NOTE**: Please update your code w.r.t the following changes to the OpenSauced API.
+>
+>Previously it returned `404` for non OpenSauced users, now it returns 200; with `is_open_sauced_member` bool in response.
+
 ```
-https://api.opensauced.pizza/v1/users/bdougie // returns 200
-https://api.opensauced.pizza/v1/users/defunkt // return 404
+GET https://api.opensauced.pizza/v1/users/bdougie
 ```
+- The reponse should contain `is_open_sauced_member: true` — i.e. `bdougie` _**is an**_ OpenSauced user/member
+- Whereas,
+```
+GET https://api.opensauced.pizza/v1/users/defunkt
+```
+- returns `is_open_sauced_member: false` — i.e. `defunkt` is _**NOT**_ an OpenSauced user/member
 
 Things to consider:
 

--- a/README.md
+++ b/README.md
@@ -85,19 +85,15 @@ API example:
 
 When viewing [bdougie](https://github.com/bdougie) you will check his handle using the users service in api.opensauced.pizza to confirm he is an OpenSauced user. When checking [defunkt](https://github.com/defunkt) you will confirm he is not an OpenSauced user.
 
->**NOTE**: Please update your code w.r.t the following changes to the OpenSauced API.
->
->Previously it returned `404` for non OpenSauced users, now it returns 200; with `is_open_sauced_member` bool in response.
-
 ```
 GET https://api.opensauced.pizza/v1/users/bdougie
 ```
-- The reponse should contain `is_open_sauced_member: true` — i.e. `bdougie` _**is an**_ OpenSauced user/member
+- Response status code: `200` 🟢 — i.e. `bdougie` _**is**_ an OpenSauced user
 - Whereas,
 ```
-GET https://api.opensauced.pizza/v1/users/defunkt
+GET https://api.opensauced.pizza/v1/users/unknown
 ```
-- returns `is_open_sauced_member: false` — i.e. `defunkt` is _**NOT**_ an OpenSauced user/member
+- returns `404` 🔴 — i.e. `unknown` is _**NOT**_ an OpenSauced user
 
 Things to consider:
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ GET https://api.opensauced.pizza/v1/users/bdougie
 - Response status code: `200` 🟢 — i.e. `bdougie` _**is**_ an OpenSauced user
 - Whereas,
 ```
-GET https://api.opensauced.pizza/v1/users/unknown
+GET https://api.opensauced.pizza/v1/users/open-sauced-robot-vortex
 ```
 - returns `404` 🔴 — i.e. `unknown` is _**NOT**_ an OpenSauced user
 


### PR DESCRIPTION
Summary

- Fixed outdated info about OS API **v1** `/users` endpoint
- The example user used for non OS user, is now an OS user
- This diff simply replaces it with the one who is _not_ atm.

--- 

--- w/ ❤️ from @Pranav-yadav & 🐼 